### PR TITLE
Feature: Bypass processing when webpack is running on debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ require("image?optimizationLevel=5&progressive=true&interlaced=true");
 
 ``` javascript
 loaders: [
-  {test: /.*\.(gif|png|jpg)$/, loaders: ['image?optimizationLevel=7&interlaced=false']}
+  {test: /\.(jpe?g|png|gif|svg)$/i, loaders: ['image?bypassOnDebug&optimizationLevel=7&interlaced=false']}
 ]
 ```
 
@@ -106,6 +106,13 @@ Type: `array`
 Default: `[]`
 
 No plugins implemented at the moment.
+
+#### bypassOnDebug *(all)*
+
+Type: `boolean`  
+Default: `false`
+
+Using this, no processing is done when webpack 'debug' mode is used and the loader acts as a regular file-loader. Use this to speed up initial and, to a lesser extent, subsequent compilations while developing or using webpack-dev-server. Normal builds are processed normally, outputting oprimized files.
 
 ## Inspiration
 

--- a/index.js
+++ b/index.js
@@ -6,35 +6,53 @@ var loaderUtils = require('loader-utils');
 
 module.exports = function(content) {
   this.cacheable && this.cacheable();
-  if(!this.emitFile) throw new Error("emitFile is required from module system");
-
-  var callback = this.async(), called = false;
-
-  var name = path.basename(this.resourcePath);
+  if (!this.emitFile) throw new Error("emitFile is required from module system");
 
   var query = loaderUtils.parseQuery(this.query);
+  var url = loaderUtils.interpolateName(this, query.name || "[hash].[ext]", {
+    context: query.context || this.options.context,
+    content: content,
+    regExp: query.regExp
+  });
   var options = {
     interlaced: query.interlaced || false,
     progressive: query.progressive || false,
-    optimizationLevel: query.optimizationLevel || 3
+    optimizationLevel: query.optimizationLevel || 3,
+    bypassOnDebug: query.bypassOnDebug || false
   }
 
-  var imagemin = new Imagemin()
+  if (this.debug === true && options.bypassOnDebug === true) {
+    // Bypass processing while on wathch mode
+    this.emitFile(url, content);
+    return "module.exports = __webpack_public_path__ + " + JSON.stringify(url);
+  } else {
+    var callback = this.async(), called = false;
+
+    var imagemin = new Imagemin()
     .src(content)
-    .use(Imagemin.gifsicle({interlaced: options.interlaced}))
-		.use(Imagemin.jpegtran({progressive: options.progressive}))
-		.use(Imagemin.optipng({optimizationLevel: options.optimizationLevel}))
+    .use(Imagemin.gifsicle({
+      interlaced: options.interlaced
+    }))
+    .use(Imagemin.jpegtran({
+      progressive: options.progressive
+    }))
+    .use(Imagemin.optipng({
+      optimizationLevel: options.optimizationLevel
+    }))
     .use(Imagemin.svgo());
 
-  imagemin.run(function (err, files) {
-    if (called) {
-      console.log("something is very odd, it is being called twice"); return;
-    }
-    called = true;
-    if (err) {
-      return callback(err);
-    }
-    callback(null, files[0].contents);
-  }.bind(this));
+    imagemin.run(function(err, files) {
+      if (called) {
+        console.log("something is very odd, it is being called twice");
+        return;
+      }
+      called = true;
+      if (err) {
+        return callback(err);
+      }
+      this.emitFile(url, files[0].contents);
+      callback(null, "module.exports = __webpack_public_path__ + " + JSON.stringify(url));
+    }.bind(this));
+  }
 };
 module.exports.raw = true;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "loader-utils": "^0.2.5"
   },
   "peerDependencies": {
-    "imagemin": "^3.0.0",
+    "imagemin": "^3.0.0"
   },
   "devDependencies": {
     "webpack": "^1.4.13",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "url": "git@github.com:tcoopman/image-webpack-loader.git"
   },
   "dependencies": {
-    "imagemin": "^3.0.0",
     "loader-utils": "^0.2.5"
+  },
+  "peerDependencies": {
+    "imagemin": "^3.0.0",
   },
   "devDependencies": {
     "webpack": "^1.4.13",


### PR DESCRIPTION
Using this, no processing is done when webpack 'debug' mode is used and the loader acts as a regular file-loader.
Use this to speed up initial and, to a lesser extent, subsequent compilations while developing or using webpack-dev-server. Normal builds are processed normally, outputting oprimized files.