### PR TITLE
Load config optionally from a section in webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,39 @@ loaders: [
 ];
 ```
 
+You can also use a configuration section in your webpack config to set global options for the loader, which will apply to all loader sections that use the image loader.
+
+```
+{
+  loaders: [
+    {
+      test: /.*\.(gif|png|jpe?g|svg)$/i,
+      loaders: [
+        'file?hash=sha512&digest=hex&name=[hash].[ext]',
+        'image-webpack'
+      ]
+    }
+  ],
+
+  imageWebpackLoader: {
+    pngquant:{
+      quality: "65-90",
+      speed: 4
+    },
+    svgo:{
+      plugins: [
+        {
+          removeViewBox: false
+        },
+        {
+          removeEmptyAttrs: false
+        }
+      ]
+    }
+  }
+}
+```
+
 Comes bundled with the following optimizers:
 
 - [gifsicle](https://github.com/kevva/imagemin-gifsicle) — *Compress GIF images*

--- a/index.js
+++ b/index.js
@@ -6,14 +6,14 @@ var loaderUtils = require('loader-utils');
 module.exports = function(content) {
   this.cacheable && this.cacheable();
 
-  var query = loaderUtils.parseQuery(this.query);
+  var config = loaderUtils.getLoaderConfig(this, "imageWebpackLoader");
   var options = {
-    interlaced: query.interlaced || false,
-    progressive: query.progressive || false,
-    optimizationLevel: query.optimizationLevel || 3,
-    bypassOnDebug: query.bypassOnDebug || false,
-    pngquant: query.pngquant || false,
-    svgo: query.svgo || {} 
+    interlaced: config.interlaced || false,
+    progressive: config.progressive || false,
+    optimizationLevel: config.optimizationLevel || 3,
+    bypassOnDebug: config.bypassOnDebug || false,
+    pngquant: config.pngquant || false,
+    svgo: config.svgo || {}
   };
 
   var callback = this.async(), called = false;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "imagemin-pngquant": "^4.2.0",
-    "loader-utils": "^0.2.12",
+    "loader-utils": "^0.2.14",
     "imagemin": "^4.0.0",
     "file-loader": "*"
   },

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -5,7 +5,7 @@ var webpack = require('webpack');
 var commonLoaders = [
   {test: /.*\.(gif|png|jpe?g|svg)$/i, loaders: [
     'file?hash=sha512&digest=hex&name=[hash].[ext]',
-    '../index.js']},
+    '../index.js?{progressive:true,optimizationLevel:7,interlaced:false}']},
 ];
 var assetsPath = path.join(__dirname, 'public/assets');
 var publicPath = 'assets/';
@@ -27,9 +27,6 @@ module.exports = [
       loaders: commonLoaders
     },
     imageWebpackLoader: {
-      progressive:true,
-      optimizationLevel: 7,
-      interlaced: false,
       pngquant:{
         quality: "65-90",
         speed: 4

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -5,7 +5,7 @@ var webpack = require('webpack');
 var commonLoaders = [
   {test: /.*\.(gif|png|jpe?g|svg)$/i, loaders: [
     'file?hash=sha512&digest=hex&name=[hash].[ext]',
-    '../index.js?{progressive:true, optimizationLevel: 7, interlaced: false, pngquant:{quality: "65-90", speed: 4}, svgo:{plugins:[{removeViewBox: false},{removeEmptyAttrs: false}]}}']},
+    '../index.js']},
 ];
 var assetsPath = path.join(__dirname, 'public/assets');
 var publicPath = 'assets/';
@@ -25,6 +25,25 @@ module.exports = [
     },
     module: {
       loaders: commonLoaders
+    },
+    imageWebpackLoader: {
+      progressive:true,
+      optimizationLevel: 7,
+      interlaced: false,
+      pngquant:{
+        quality: "65-90",
+        speed: 4
+      },
+      svgo:{
+        plugins: [
+          {
+            removeViewBox: false
+          },
+          {
+            removeEmptyAttrs: false
+          }
+        ]
+      }
     }
   }
 ];


### PR DESCRIPTION
Uses the loader util function `getLoaderConfig` (https://github.com/webpack/loader-utils#getloaderconfig) to get config, which loads from both the query string (backwards compatible) and from a config section named `imageWebpackLoader`. See test config for example usage.

Fixes https://github.com/tcoopman/image-webpack-loader/issues/30