### PR TITLE
Use mozjpeg instead of jpegtran

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 npm-debug.log
 test/public
+*.sublime-project
+*.sublime-workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+## [3.0.0] - 2016-10-16
+### Changed
+- Changed jpeg compression algorithm from jpegtran to mozjpeg [PR#38](https://github.com/tcoopman/image-webpack-loader/pull/38).
+See [imagemin-mozjpeg](https://github.com/imagemin/imagemin-mozjpeg) for configuration options. 
+- Updated minor versions of dependencies: `loader-utils`, `imagemin-gifsicle`,  `imagemin-optipng`, `imagemin-svgo`, `webpack`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ loaders: [
 ]
 ```
 
-If you want to use [pngquant](https://pngquant.org/) you must use the json options
+If you want to use [pngquant](https://pngquant.org/) or [mozjpeg](https://github.com/mozilla/mozjpeg) you must use the json options
 notation like this:
 
 ```javascript
@@ -39,7 +39,7 @@ loaders: [
     test: /.*\.(gif|png|jpe?g|svg)$/i,
     loaders: [
       'file?hash=sha512&digest=hex&name=[hash].[ext]',
-      'image-webpack?{progressive:true, optimizationLevel: 7, interlaced: false, pngquant:{quality: "65-90", speed: 4}}'
+      'image-webpack?{optimizationLevel: 7, interlaced: false, pngquant:{quality: "65-90", speed: 4}, mozjpeg: {quality: 65}}'
     ]
   }
 ];
@@ -62,6 +62,9 @@ You can also use a configuration section in your webpack config to set global op
   },
 
   imageWebpackLoader: {
+    mozjpeg: {
+      quality: 65
+    },
     pngquant:{
       quality: "65-90",
       speed: 4
@@ -83,7 +86,7 @@ You can also use a configuration section in your webpack config to set global op
 Comes bundled with the following optimizers:
 
 - [gifsicle](https://github.com/kevva/imagemin-gifsicle) — *Compress GIF images*
-- [jpegtran](https://github.com/kevva/imagemin-jpegtran) — *Compress JPEG images*
+- [mozjpeg](https://github.com/imagemin/imagemin-mozjpeg) — *Compress JPEG images*
 - [optipng](https://github.com/kevva/imagemin-optipng) — *Compress PNG images*
 - [svgo](https://github.com/kevva/imagemin-svgo) — *Compress SVG images*
 - [pngquant](https://pngquant.org/) — *Compress PNG images*
@@ -98,7 +101,7 @@ Options are applied to the correct files.
 
 #### optimizationLevel *(png)*
 
-Type: `number`  
+Type: `number`
 Default: `3`
 
 Select an optimization level between `0` and `7`.
@@ -115,16 +118,28 @@ Level and trials:
 6. 120 trials
 7. 240 trials
 
-#### progressive *(jpg)*
+### imageminMozjpeg(options)
 
-Type: `boolean`  
-Default: `false`
+Returns a promise for a buffer.
 
-Lossless conversion to progressive.
+#### options
+
+##### quality
+
+Type: `number`
+
+Compression quality. Min and max are numbers in range 0 (worst) to 100 (perfect).
+
+##### progressive
+
+Type: `boolean`<br>
+Default: `true`
+
+`false` creates baseline JPEG file.
 
 #### interlaced *(gif)*
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Interlace gif for progressive rendering.
@@ -138,7 +153,7 @@ Pass options to [svgo](https://github.com/svg/svgo).
 
 #### bypassOnDebug *(all)*
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Using this, no processing is done when webpack 'debug' mode is used and the loader acts as a regular file-loader. Use this to speed up initial and, to a lesser extent, subsequent compilations while developing or using webpack-dev-server. Normal builds are processed normally, outputting oprimized files.
@@ -147,14 +162,14 @@ Using this, no processing is done when webpack 'debug' mode is used and the load
 
 #### options.floyd
 
-Type: `number`  
+Type: `number`
 Default: `0.5`
 
 Controls level of dithering (0 = none, 1 = full).
 
 #### options.nofs
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Disable Floyd-Steinberg dithering.
@@ -178,7 +193,7 @@ Min and max are numbers in range 0 (worst) to 100 (perfect), similar to JPEG.
 
 #### options.speed
 
-Type: `number`  
+Type: `number`
 Default: `3`
 
 Speed/quality trade-off from `1` (brute-force) to `10` (fastest). Speed `10` has
@@ -186,7 +201,7 @@ Speed/quality trade-off from `1` (brute-force) to `10` (fastest). Speed `10` has
 
 #### options.verbose
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Print verbose status messages.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![Dependencies status](https://david-dm.org/tcoopman/image-webpack-loader/status.svg)
+![devDependencies status](https://david-dm.org/tcoopman/image-webpack-loader/dev-status.svg)
+
 # image-loader
 
 Image loader module for webpack

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var imageminSvgo = require('imagemin-svgo');
 var imageminPngquant = require('imagemin-pngquant');
 var loaderUtils = require('loader-utils');
 
-
 module.exports = function(content) {
   this.cacheable && this.cacheable();
 
@@ -20,21 +19,28 @@ module.exports = function(content) {
     svgo: config.svgo || {}
   };
 
-  var callback = this.async(), called = false;
+  var callback = this.async(),
+    called = false;
 
   if (this.debug === true && options.bypassOnDebug === true) {
     // Bypass processing while on watch mode
     return callback(null, content);
   } else {
     var plugins = [];
-    plugins.push(imageminGifsicle({interlaced: options.interlaced}));
+    plugins.push(imageminGifsicle({
+      interlaced: options.interlaced
+    }));
     plugins.push(imageminMozjpeg(options.mozjpeg));
     plugins.push(imageminSvgo(options.svgo));
     plugins.push(imageminPngquant(options.pngquant));
-    plugins.push(imageminOptipng({optimizationLevel: options.optimizationLevel}));
+    plugins.push(imageminOptipng({
+      optimizationLevel: options.optimizationLevel
+    }));
 
     imagemin
-      .buffer(content, {plugins})
+      .buffer(content, {
+        plugins
+      })
       .then(data => {
         callback(null, data);
       })
@@ -43,4 +49,5 @@ module.exports = function(content) {
       });
   }
 };
+
 module.exports.raw = true;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var imagemin = require('imagemin');
 var imageminGifsicle = require('imagemin-gifsicle');
-var imageminJpegtran = require('imagemin-jpegtran');
+var imageminMozjpeg = require('imagemin-mozjpeg');
 var imageminOptipng = require('imagemin-optipng');
 var imageminSvgo = require('imagemin-svgo');
 var imageminPngquant = require('imagemin-pngquant');
@@ -13,9 +13,9 @@ module.exports = function(content) {
   var config = loaderUtils.getLoaderConfig(this, "imageWebpackLoader");
   var options = {
     interlaced: config.interlaced || false,
-    progressive: config.progressive || false,
     optimizationLevel: config.optimizationLevel || 3,
     bypassOnDebug: config.bypassOnDebug || false,
+    mozjpeg: config.mozjpeg || false,
     pngquant: config.pngquant || false,
     svgo: config.svgo || {}
   };
@@ -28,7 +28,7 @@ module.exports = function(content) {
   } else {
     var plugins = [];
     plugins.push(imageminGifsicle({interlaced: options.interlaced}));
-    plugins.push(imageminJpegtran({progressive: options.progressive}));
+    plugins.push(imageminMozjpeg(options.mozjpeg));
     plugins.push(imageminSvgo(options.svgo));
     plugins.push(imageminPngquant(options.pngquant));
     plugins.push(imageminOptipng({optimizationLevel: options.optimizationLevel}));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-webpack-loader",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Image loader module for webpack",
   "author": "Thomas Coopman @tcoopman",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,23 +3,18 @@
   "version": "3.0.0",
   "description": "Image loader module for webpack",
   "author": "Thomas Coopman @tcoopman",
-  "scripts": {
-    "test": "node node_modules/webpack/bin/webpack.js --config test/webpack.config.js"
-  },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git@github.com:tcoopman/image-webpack-loader.git"
   },
+  "scripts": {
+    "test": "rm -rf test/public/assets && ./node_modules/.bin/webpack --config test/webpack.config.js"
+  },
   "dependencies": {
     "loader-utils": "^0.2.16",
     "imagemin": "^5.2.2",
-    "file-loader": "*",
+    "file-loader": "^0.9.0",
     "imagemin-gifsicle": "^5.1.0",
     "imagemin-mozjpeg": "^6.0.0",
     "imagemin-optipng": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "imagemin": "^5.2.2",
     "file-loader": "*",
     "imagemin-gifsicle": "^5.0.0",
-    "imagemin-jpegtran": "^5.0.0",
     "imagemin-optipng": "^5.1.0",
     "imagemin-svgo": "^5.1.0",
+    "imagemin-mozjpeg": "^6.0.0",
     "imagemin-pngquant": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,16 +17,16 @@
     "url": "git@github.com:tcoopman/image-webpack-loader.git"
   },
   "dependencies": {
-    "loader-utils": "^0.2.15",
+    "loader-utils": "^0.2.16",
     "imagemin": "^5.2.2",
     "file-loader": "*",
-    "imagemin-gifsicle": "^5.0.0",
-    "imagemin-optipng": "^5.1.0",
-    "imagemin-svgo": "^5.1.0",
+    "imagemin-gifsicle": "^5.1.0",
     "imagemin-mozjpeg": "^6.0.0",
+    "imagemin-optipng": "^5.2.1",
+    "imagemin-svgo": "^5.2.0",
     "imagemin-pngquant": "^5.0.0"
   },
   "devDependencies": {
-    "webpack": "^1.13.1"
+    "webpack": "^1.13.2"
   }
 }

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -8,19 +8,13 @@ var commonLoaders = [
     '../index.js?{optimizationLevel:7,interlaced:false}']},
 ];
 var assetsPath = path.join(__dirname, 'public/assets');
-var publicPath = 'assets/';
-var extensions = [''];
 
 module.exports = [
   {
     entry: './test/app.js',
     output: {
       path: assetsPath,
-      publicPath: publicPath,
       filename: 'app.[hash].js'
-    },
-    resolve: {
-      extensions: extensions
     },
     module: {
       loaders: commonLoaders

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -5,7 +5,7 @@ var webpack = require('webpack');
 var commonLoaders = [
   {test: /.*\.(gif|png|jpe?g|svg)$/i, loaders: [
     'file?hash=sha512&digest=hex&name=[hash].[ext]',
-    '../index.js?{progressive:true,optimizationLevel:7,interlaced:false}']},
+    '../index.js?{optimizationLevel:7,interlaced:false}']},
 ];
 var assetsPath = path.join(__dirname, 'public/assets');
 var publicPath = 'assets/';
@@ -26,6 +26,9 @@ module.exports = [
       loaders: commonLoaders
     },
     imageWebpackLoader: {
+      mozjpeg: {
+        quality: 65
+      },
       pngquant:{
         quality: "65-90",
         speed: 4


### PR DESCRIPTION
Hi,

I experimented with mozjpeg and it looks like it produces much better results than jpegtran.


jpegtran:
```
    f72836bbac59ca5e265a0fc7591dfd09.jpg  2.43 MB          [emitted]
```
Mozjpeg:
```
    b47f5167a0c34fca03f17dc35df9358d.jpg  1.21 MB          [emitted]
```

I couldn't see much of a difference on 300% zoom when i was testing on quality 75, but i set the default quality to 80 anyway. Hope you like it, I sure do like those smaller images.

PS. Dont mind the whitespace diff, it's just something my editor does with trailing spaces.