### PR TITLE
Changed README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ loaders: [
     loaders: [
       'file-loader',
       {
-        loader: 'image-webpack',
+        loader: 'image-webpack-loader',
         query: {
           progressive: true,
           optimizationLevel: 7,


### PR DESCRIPTION
Due to a breaking change in Webpack 2, using a loader without '-loader' on the end causes webpack 2 (2.2.0-rc.3) to throw an error.
I simply changed the README example so it would not cause this error.