### PR TITLE
Avoid using greedy regex in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ notation like this:
 ```javascript
 loaders: [
   {
-    test: /.*\.(gif|png|jpe?g|svg)$/i,
+    test: /\.(gif|png|jpe?g|svg)$/i,
     loaders: [
       'file?hash=sha512&digest=hex&name=[hash].[ext]',
       'image-webpack?{optimizationLevel: 7, interlaced: false, pngquant:{quality: "65-90", speed: 4}, mozjpeg: {quality: 65}}'
@@ -67,7 +67,7 @@ You can also use a configuration section in your webpack config to set global op
   module: {
     loaders: [
       {
-        test: /.*\.(gif|png|jpe?g|svg)$/i,
+        test: /\.(gif|png|jpe?g|svg)$/i,
         loaders: [
           'file?hash=sha512&digest=hex&name=[hash].[ext]',
           'image-webpack'
@@ -103,7 +103,7 @@ With webpack 2 now supporting query object syntax, you can also write as
 
 loaders: [
   {
-    test: /.*\.(gif|png|jpe?g|svg)$/i,
+    test: /\.(gif|png|jpe?g|svg)$/i,
     loaders: [
       'file-loader',
       {


### PR DESCRIPTION
According to some benchmarks, the greedy versions run ~20% slower than the simple non-greedy version with a fairly shallow file path. This gets worse  when filepaths are more deeply nested. 

This ended up causing some slowness in my initial webpack builds, so I figure we can save a few users some headaches :)