### PR TITLE
Clarify which optimisers are enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ loaders: [{
 }]
 ```
 
-Comes bundled with the following optimizers:
+Comes bundled with the following optimizers, which are automatically enabled by default:
 
 - [mozjpeg](https://github.com/imagemin/imagemin-mozjpeg) — *Compress JPEG images*
 - [optipng](https://github.com/kevva/imagemin-optipng) — *Compress PNG images*


### PR DESCRIPTION
Minor update to the readme to help clarify which optimisers are enabled by default. 