### PR TITLE
Bump imagemin-svgo to v6.0.0 for svgo v1.0.0, better compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "imagemin-mozjpeg": "^7.0.0",
     "imagemin-optipng": "^5.2.1",
     "imagemin-pngquant": "^5.0.0",
-    "imagemin-svgo": "^5.2.1",
+    "imagemin-svgo": "^6.0.0",
     "imagemin-webp": "^4.0.0",
     "loader-utils": "^1.1.0",
     "object-assign": "^4.1.1"


### PR DESCRIPTION
I noticed that svgo 1.0.0 compresses my svgs to a smaller size. Can we update this dependency? @tcoopman 