### PR TITLE
Move webpack-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "imagemin-svgo": "^6.0.0",
     "imagemin-webp": "^4.1.0",
     "loader-utils": "^1.1.0",
-    "object-assign": "^4.1.1",
-    "webpack-cli": "^2.1.3"
+    "object-assign": "^4.1.1"
   },
   "devDependencies": {
     "file-loader": "^1.1.11",
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.2",
+    "webpack-cli": "^2.1.3"
   }
 }


### PR DESCRIPTION
It's only used for tests! It's a very large dependency so it's nice to
not have to install it.

Thanks!