### PR TITLE
Added ability to use additional optimizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,15 @@ rules: [{
         webp: {
           quality: 75
         }
-      }
+      },
+      additionalPlugins: [
+          {
+              plugin: 'imagemin-jpegtran',
+              options: {
+                  progressive: true
+              }
+          }
+      ]
     },
   ],
 }]
@@ -95,6 +103,10 @@ Comes bundled with the following optimizers, which are automatically enabled by 
 And optional optimizers:
 
 - [webp](https://github.com/imagemin/imagemin-webp) — *Compress JPG & PNG images into WEBP*
+
+And you may include additional imagemin plugins and their options by defining them in additionalPlugins. You must manually install each additional plugin as a node module before using it with image-webpack-loader.
+
+[Plugins](https://www.npmjs.com/search?q=keywords:imageminplugin) to use.
 
 _Default optimizers can be disabled by specifying `optimizer.enabled: false`, and optional ones can be enabled by simply putting them in the options_
 

--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ rules: [{
         }
       },
       additionalPlugins: [
-          {
-              plugin: 'imagemin-jpegtran',
-              options: {
-                  progressive: true
-              }
+        {
+          plugin: 'imagemin-jpegtran',
+          options: {
+            progressive: true
           }
+        }
       ]
     },
   ],

--- a/index.js
+++ b/index.js
@@ -37,8 +37,10 @@ module.exports = function(content) {
     optipng: config.optipng || {},
     svgo: config.svgo || {},
     // optional optimizers
-    webp: config.webp || null
+    webp: config.webp || null,
+    additionalPlugins: config.additionalPlugins || []
   };
+
   // Remove in interlaced, progressive and optimizationLevel checks in new major version
   if (config.hasOwnProperty('interlaced')) {
     options.gifsicle.interlaced = config.interlaced;
@@ -75,6 +77,11 @@ module.exports = function(content) {
     // optional optimizers
     if(options.webp)
       plugins.push(require('imagemin-webp')(options.webp));
+    // additional optimizers
+    options.additionalPlugins.forEach((plugin) => {
+      plugin.options = plugin.options || {};
+      plugins.push(require(plugin.plugin)(plugin.options));
+    });
 
     imagemin
       .buffer(content, {


### PR DESCRIPTION
To add the ability to use additional optimizers without editing the core loader, I have added the option additionalPlugins to the loader options. Using this, a user can define an additional imagemin plugin to use, along with it's options, and the loader will utilize that optimizer as well (as long as it is installed as a node module).