### PR TITLE
chore: upgrade imagemin-webp to v7.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,14 @@ module.exports = function(content) {
     if(options.optipng.enabled !== false)
       plugins.push(require('imagemin-optipng')(options.optipng));
     // optional optimizers
-    if(options.webp.enabled !== false)
-      plugins.push(require('imagemin-webp')(options.webp));
+    if(options.webp.enabled !== false) {
+      async function loadWebp() {
+        await import('imagemin-webp').then(({ default: imageminWebp}) => {
+          plugins.push(imageminWebp(options.webp));
+        });
+      }
+      loadWebp()
+    }
 
     imagemin
       .buffer(content, {

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = function(content) {
     // optional optimizers
     if(options.webp.enabled !== false) {
       async function loadWebp() {
-        await import('imagemin-webp').then(({ default: imageminWebp}) => {
+        await import('imagemin-webp').then(({ default: imageminWebp }) => {
           plugins.push(imageminWebp(options.webp));
         });
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "file-loader": "^6.2.0",
         "rimraf": "^3.0.2",
         "webpack": "^4.46.0",
-        "webpack-cli": "^4.8.0"
+        "webpack-cli": "^4.9.1"
       },
       "optionalDependencies": {
         "imagemin-gifsicle": "^7.0.0",
@@ -26,7 +26,7 @@
         "imagemin-optipng": "^8.0.0",
         "imagemin-pngquant": "^9.0.2",
         "imagemin-svgo": "^9.0.0",
-        "imagemin-webp": "^6.0.0"
+        "imagemin-webp": "^7.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -285,28 +285,6 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
-      "integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
-      "dev": true,
-      "peerDependencies": {
-        "webpack": "4.x.x || 5.x.x",
-        "webpack-cli": "4.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
-      "integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
-      "dev": true,
-      "dependencies": {
-        "envinfo": "^7.7.3"
-      },
-      "peerDependencies": {
-        "webpack-cli": "4.x.x"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -1486,9 +1464,9 @@
       }
     },
     "node_modules/colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
     },
     "node_modules/commander": {
@@ -1764,21 +1742,23 @@
       }
     },
     "node_modules/cwebp-bin": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-5.1.0.tgz",
-      "integrity": "sha512-BsPKStaNr98zfxwejWWLIGELbPERULJoD2v5ijvpeutSAGsegX7gmABgnkRK7MUucCPROXXfaPqkLAwI509JzA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-7.0.1.tgz",
+      "integrity": "sha512-Ko5ADY74/dbfd8xG0+f+MUP9UKjCe1TG4ehpW0E5y4YlPdwDJlGrSzSR4/Yonxpm9QmZE1RratkIxFlKeyo3FA==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "bin-build": "^3.0.0",
-        "bin-wrapper": "^4.0.1",
-        "logalot": "^2.1.0"
+        "bin-wrapper": "^4.0.1"
       },
       "bin": {
         "cwebp": "cli.js"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/imagemin/cwebp-bin?sponsor=1"
       }
     },
     "node_modules/cyclist": {
@@ -3738,17 +3718,17 @@
       }
     },
     "node_modules/imagemin-webp": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-6.0.0.tgz",
-      "integrity": "sha512-DmVCkI8H1csyqAExsk93LzC88gj2uKXaLLW5Ly+WYsvNx7xv5cJAlozXWIx9Z0kEQr9w98gphi5aP2b++iDH8g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-7.0.0.tgz",
+      "integrity": "sha512-JoYjvHNgBLgrQAkeCO7T5iNc8XVpiBmMPZmiXMhalC7K6gwY/3DCEUfNxVPOmNJ+NIJlJFvzcMR9RBxIE74Xxw==",
       "optional": true,
       "dependencies": {
-        "cwebp-bin": "^5.0.0",
-        "exec-buffer": "^3.0.0",
+        "cwebp-bin": "^7.0.1",
+        "exec-buffer": "^3.2.0",
         "is-cwebp-readable": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/imagemin/node_modules/make-dir": {
@@ -7206,12 +7186,6 @@
         "uuid": "bin/uuid"
       }
     },
-    "node_modules/v8-compile-cache": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
-      "dev": true
-    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -7427,23 +7401,22 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
-      "integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
+      "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
       "dev": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.0.4",
-        "@webpack-cli/info": "^1.3.0",
-        "@webpack-cli/serve": "^1.5.2",
-        "colorette": "^1.2.1",
+        "@webpack-cli/configtest": "^1.1.0",
+        "@webpack-cli/info": "^1.4.0",
+        "@webpack-cli/serve": "^1.6.0",
+        "colorette": "^2.0.14",
         "commander": "^7.0.0",
         "execa": "^5.0.0",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
         "interpret": "^2.2.0",
         "rechoir": "^0.7.0",
-        "v8-compile-cache": "^2.2.0",
         "webpack-merge": "^5.7.3"
       },
       "bin": {
@@ -7470,10 +7443,32 @@
         }
       }
     },
+    "node_modules/webpack-cli/node_modules/@webpack-cli/configtest": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+      "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x",
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/webpack-cli/node_modules/@webpack-cli/info": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+      "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+      "dev": true,
+      "dependencies": {
+        "envinfo": "^7.7.3"
+      },
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      }
+    },
     "node_modules/webpack-cli/node_modules/@webpack-cli/serve": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
-      "integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+      "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
       "dev": true,
       "peerDependencies": {
         "webpack-cli": "4.x.x"
@@ -7998,22 +7993,6 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webpack-cli/configtest": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.0.4.tgz",
-      "integrity": "sha512-cs3XLy+UcxiP6bj0A6u7MLLuwdXJ1c3Dtc0RkKg+wiI1g/Ti1om8+/2hc2A2B60NbBNAbMgyBMHvyymWm/j4wQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "@webpack-cli/info": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.3.0.tgz",
-      "integrity": "sha512-ASiVB3t9LOKHs5DyVUcxpraBXDOKubYu/ihHhU+t1UPpxsivg6Od2E2qU4gJCekfEddzRBzHhzA/Acyw/mlK/w==",
-      "dev": true,
-      "requires": {
-        "envinfo": "^7.7.3"
       }
     },
     "@xtuc/ieee754": {
@@ -9022,9 +9001,9 @@
       }
     },
     "colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
     },
     "commander": {
@@ -9267,14 +9246,13 @@
       }
     },
     "cwebp-bin": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-5.1.0.tgz",
-      "integrity": "sha512-BsPKStaNr98zfxwejWWLIGELbPERULJoD2v5ijvpeutSAGsegX7gmABgnkRK7MUucCPROXXfaPqkLAwI509JzA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cwebp-bin/-/cwebp-bin-7.0.1.tgz",
+      "integrity": "sha512-Ko5ADY74/dbfd8xG0+f+MUP9UKjCe1TG4ehpW0E5y4YlPdwDJlGrSzSR4/Yonxpm9QmZE1RratkIxFlKeyo3FA==",
       "optional": true,
       "requires": {
         "bin-build": "^3.0.0",
-        "bin-wrapper": "^4.0.1",
-        "logalot": "^2.1.0"
+        "bin-wrapper": "^4.0.1"
       }
     },
     "cyclist": {
@@ -10855,13 +10833,13 @@
       }
     },
     "imagemin-webp": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-6.0.0.tgz",
-      "integrity": "sha512-DmVCkI8H1csyqAExsk93LzC88gj2uKXaLLW5Ly+WYsvNx7xv5cJAlozXWIx9Z0kEQr9w98gphi5aP2b++iDH8g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-7.0.0.tgz",
+      "integrity": "sha512-JoYjvHNgBLgrQAkeCO7T5iNc8XVpiBmMPZmiXMhalC7K6gwY/3DCEUfNxVPOmNJ+NIJlJFvzcMR9RBxIE74Xxw==",
       "optional": true,
       "requires": {
-        "cwebp-bin": "^5.0.0",
-        "exec-buffer": "^3.0.0",
+        "cwebp-bin": "^7.0.1",
+        "exec-buffer": "^3.2.0",
         "is-cwebp-readable": "^3.0.0"
       }
     },
@@ -13649,12 +13627,6 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "optional": true
     },
-    "v8-compile-cache": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
-      "dev": true
-    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -13873,30 +13845,45 @@
       }
     },
     "webpack-cli": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.8.0.tgz",
-      "integrity": "sha512-+iBSWsX16uVna5aAYN6/wjhJy1q/GKk4KjKvfg90/6hykCTSgozbfz5iRgDTSJt/LgSbYxdBX3KBHeobIs+ZEw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
+      "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
       "dev": true,
       "requires": {
         "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^1.0.4",
-        "@webpack-cli/info": "^1.3.0",
-        "@webpack-cli/serve": "^1.5.2",
-        "colorette": "^1.2.1",
+        "@webpack-cli/configtest": "^1.1.0",
+        "@webpack-cli/info": "^1.4.0",
+        "@webpack-cli/serve": "^1.6.0",
+        "colorette": "^2.0.14",
         "commander": "^7.0.0",
         "execa": "^5.0.0",
         "fastest-levenshtein": "^1.0.12",
         "import-local": "^3.0.2",
         "interpret": "^2.2.0",
         "rechoir": "^0.7.0",
-        "v8-compile-cache": "^2.2.0",
         "webpack-merge": "^5.7.3"
       },
       "dependencies": {
+        "@webpack-cli/configtest": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
+          "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
+          "dev": true,
+          "requires": {}
+        },
+        "@webpack-cli/info": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
+          "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
+          "dev": true,
+          "requires": {
+            "envinfo": "^7.7.3"
+          }
+        },
         "@webpack-cli/serve": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.5.2.tgz",
-          "integrity": "sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==",
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
+          "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
           "dev": true,
           "requires": {}
         },

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "imagemin-optipng": "^8.0.0",
     "imagemin-pngquant": "^9.0.2",
     "imagemin-svgo": "^9.0.0",
-    "imagemin-webp": "^6.0.0"
+    "imagemin-webp": "^7.0.0"
   },
   "devDependencies": {
     "file-loader": "^6.2.0",
     "rimraf": "^3.0.2",
     "webpack": "^4.46.0",
-    "webpack-cli": "^4.8.0"
+    "webpack-cli": "^4.9.1"
   }
 }


### PR DESCRIPTION
Related to https://github.com/tcoopman/image-webpack-loader/pull/412, this PR upgrades `imagemin-webp` from v6 to v7. Per the release notes, v7 changes it output format to ESM which necessitates the use of `import` instead of `require`, which can also be noted in the failing CI in the above linked PR from dependabot:

> Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /home/runner/work/image-webpack-loader/image-webpack-loader/node_modules/imagemin-webp/index.js
require() of ES modules is not supported.

After changing to `import`, the previously failing `npm run test` is now passing while using `imagemin-webp@7`.

This is required to upgrade/remove a transient dependency `trim-newlines` which currently has a "High" security vulnerability, causing Dependabot alerts across several repositories.